### PR TITLE
Add description attribute to command decorator

### DIFF
--- a/curious/commands/cmd.py
+++ b/curious/commands/cmd.py
@@ -79,7 +79,7 @@ class Command(object):
     def __init__(self, cbl, *,
                  name: str = None, aliases: typing.List[str] = None,
                  invokation_checks: list = None, group: bool = False,
-                 overridable: bool=False):
+                 overridable: bool=False, description: str = None):
         """
         :param cbl: The callable to use.
         :param name: The name of this command.
@@ -88,6 +88,7 @@ class Command(object):
         :param aliases: A list of aliases that this command can be called as.
         :param group: Is this the root command for a group?
         :param overridable: Can this command be overridden?
+        :param description: This command's description (for e.g. help purposes)
         """
         self.callable = cbl
 
@@ -97,6 +98,7 @@ class Command(object):
             # This isn't always accurate, but you should provide `name=` if you want that.
             self.name = self.callable.__name__
 
+        self.description = description if description is not None else inspect.getdoc(self.callable)
         self.aliases = [self.name] + (aliases if aliases else [])
 
         # Pre-calculate the function signature.
@@ -223,7 +225,7 @@ class Command(object):
         """
         :return: The help text for this command.
         """
-        doc = inspect.getdoc(self.callable)
+        doc = self.description
         if not doc:
             return "This command has no help."
         else:

--- a/curious/commands/cmd.py
+++ b/curious/commands/cmd.py
@@ -98,7 +98,7 @@ class Command(object):
             # This isn't always accurate, but you should provide `name=` if you want that.
             self.name = self.callable.__name__
 
-        self.description = description if description is not None else inspect.getdoc(self.callable)
+        self.description = description or inspect.getdoc(self.callable)
         self.aliases = [self.name] + (aliases if aliases else [])
 
         # Pre-calculate the function signature.

--- a/curious/commands/cmd.py
+++ b/curious/commands/cmd.py
@@ -88,7 +88,7 @@ class Command(object):
         :param aliases: A list of aliases that this command can be called as.
         :param group: Is this the root command for a group?
         :param overridable: Can this command be overridden?
-        :param description: This command's description (for e.g. help purposes)
+        :param description: This command's description (for e.g. help purposes).
         """
         self.callable = cbl
 
@@ -98,7 +98,7 @@ class Command(object):
             # This isn't always accurate, but you should provide `name=` if you want that.
             self.name = self.callable.__name__
 
-        self.description = description or inspect.getdoc(self.callable)
+        self.description = description
         self.aliases = [self.name] + (aliases if aliases else [])
 
         # Pre-calculate the function signature.
@@ -225,7 +225,7 @@ class Command(object):
         """
         :return: The help text for this command.
         """
-        doc = self.description
+        doc = self.description or inspect.getdoc(self.callable)
         if not doc:
             return "This command has no help."
         else:


### PR DESCRIPTION
This allows to explicitly override the docstring for command's description for e.g. help purposes