### PR TITLE
fix voice_members

### DIFF
--- a/curious/dataclasses/channel.py
+++ b/curious/dataclasses/channel.py
@@ -749,7 +749,7 @@ class Channel(Dataclass):
             raise CuriousError("No members for channels that aren't voice channels")
 
         return list(
-            filter(lambda member: member.voice.channel == self, self.guild.members.values())
+            filter(lambda member: member.voice and member.voice.channel == self, self.guild.members.values())
         )
 
     @property


### PR DESCRIPTION
With #23 merged this could also be rewritten to just use guild.voice_states instead of iterating over every member, which would make it more efficient in the usual case that there are many members, but only a few of them are in a voice channel at a time