### PR TITLE
fix crash on autoshard=False

### DIFF
--- a/curious/core/client.py
+++ b/curious/core/client.py
@@ -683,6 +683,8 @@ class Client(object):
         """
         if autoshard:
             shard_count = await self.get_shard_count()
+        else:
+            await self.get_gateway_url()
 
         self.shard_count = shard_count
         return await self.start(shard_count)


### PR DESCRIPTION
get_shard_count sets self._gw_url as a side effect...
so does get_gateway_url... So call the latter when we do not need the
shard count.