### PR TITLE
fix create_channel and wait_for_manager

### DIFF
--- a/curious/core/event.py
+++ b/curious/core/event.py
@@ -58,8 +58,9 @@ async def _wait_for_manager(manager, name: str, predicate):
             partial = functools.partial(manager.wait_for, name, predicate)
             await multio.asynclib.spawn(tg, partial)
             yield
-        finally:
+        except:
             await multio.asynclib.cancel_task_group(tg)
+            raise
 
 
 class EventManager(object):

--- a/curious/core/httpclient.py
+++ b/curious/core/httpclient.py
@@ -1159,7 +1159,7 @@ class HTTPClient(object):
 
     async def create_channel(self, guild_id: int, name: str, type: int, *,
                              bitrate: int = None, user_limit: int = None,
-                             permission_overwrites: list = None):
+                             parent_id: int = None, permission_overwrites: list = None):
         """
         Creates a new channel.
 
@@ -1168,6 +1168,7 @@ class HTTPClient(object):
         :param type: The type of the channel (text/voice).
         :param bitrate: The bitrate of the channel, if it is a voice channel.
         :param user_limit: The maximum number of users that can be in the channel.
+        :param parent_id: The ID of the parent.
         :param permission_overwrites: The list of permission overwrites to use for this channel.
         """
         url = Endpoints.GUILD_CHANNELS.format(guild_id=guild_id)
@@ -1182,6 +1183,9 @@ class HTTPClient(object):
 
             if user_limit is not None:
                 payload["user_limit"] = user_limit
+
+        if parent_id is not None:
+            payload["parent_id"] = parent_id
 
         if permission_overwrites is not None:
             payload["permission_overwrites"] = permission_overwrites


### PR DESCRIPTION
wait_for_manager didn't wait at all and was essentially a fancy no-op.

create_channel was missing the parent_id parameter, and gave the bitrate
in kbit/s while Discord expects bit/s for some reason.

Also, create_channel wasn't waiting for the channel to be created (due
to the broken wait_for_manager)