### PR TITLE
use (current) v6 api version

### DIFF
--- a/curious/core/httpclient.py
+++ b/curious/core/httpclient.py
@@ -150,7 +150,7 @@ def encode_multipart(fields, files, boundary=None):
 
 # more of a namespace
 class Endpoints:
-    API_BASE = "/api/v7"
+    API_BASE = "/api/v6"
 
     USER_ID = "/users/{user_id}"
     USER_ME = "/users/@me"


### PR DESCRIPTION
Discord seems to allow larger version numbers, but v7 isn't released
yet, so we probably should not claim we use it.